### PR TITLE
Experimenting with TextTask training on Penn Treebank.

### DIFF
--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -17,16 +17,24 @@ class TextTask(Task):
         super().__init__()
         self.context_length = context_length
         self.text_tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
-        text_datasets_list = []
-        assert len(dataset_names) == len(dataset_paths), "The dataset names and paths parameters should have corresponding values and hence equal lengths"
-        for i, text_dataset in enumerate(dataset_names):
-            text_datasets_list.append(load_dataset(path=dataset_paths[i], name=text_dataset))
-        if len(text_datasets_list) == 1:
-            self.text_dataset = text_datasets_list[0]
-        else:            
-            # https://huggingface.co/docs/datasets/v2.14.4/en/process#concatenate
-            # must have the same feature columns
-            self.text_dataset = concatenate_datasets(text_datasets_list)
+        # text_datasets_list = []
+        # assert len(dataset_names) == len(dataset_paths), "The dataset names and paths parameters should have corresponding values and hence equal lengths"
+        # for i, text_dataset in enumerate(dataset_names):
+        #     text_datasets_list.append(load_dataset(path=dataset_paths[i], name=text_dataset))
+        # if len(text_datasets_list) == 1:
+        #     self.text_dataset = text_datasets_list[0]
+        # else:
+        #     # https://huggingface.co/docs/datasets/v2.14.4/en/process#concatenate
+        #     # must have the same feature columns
+        #     self.text_dataset = concatenate_datasets(text_datasets_list)
+        #
+        #
+        # Checkout Huggingface datasets version 2.5.2. That's the most recent version that includes `ptb_text_only`. Load the dataset
+        # so that you'll have it cached. Then use that directory.
+        dspath = '/home/eihli/.cache/huggingface/datasets/ptb_text_only/penn_treebank/1.1.0/8d1b97746fb9765d140e569ec5ddd35e20af4d37761f5e1bf357ea0b081f2c1f'
+        ds = load_dataset(dspath)
+        ds = ds.rename_column('sentence', 'text')
+        self.text_dataset = ds
 
         
     def sample_batch(self, batch_size, is_test=False)->List[Dict]:

--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -89,7 +89,9 @@ class TextTask(Task):
             
             # Split the tokens into input and target tokens
             tokens = batch_dict['text']
-            ith_position = np.random.randint(0, len(tokens))
+            if len(tokens) <= 1:
+                continue
+            ith_position = np.random.randint(1, len(tokens))
             input_tokens = tokens[:ith_position]
             target_tokens = tokens[ith_position:]
 

--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -89,7 +89,7 @@ class TextTask(Task):
             
             # Split the tokens into input and target tokens
             tokens = batch_dict['text']
-            ith_position = np.random.randint(1, len(tokens))
+            ith_position = np.random.randint(0, len(tokens))
             input_tokens = tokens[:ith_position]
             target_tokens = tokens[ith_position:]
 


### PR DESCRIPTION
First training run shows perplexity and loss growing.

```
accelerate launch train.py \
    --use_wandb \
    --layers=6 \
    --heads=16 \
    --training_steps=800 \
    --log_eval_freq=20 \
    --warmup_steps=20 \
    --batch_size=32 \
    --eval_episodes=40 \
    --activation_fn=gelu \
    --save_model \
    --save_mode=checkpoint \
    --text_prop=1 \
    --eval_text_log_examples \
    --text_datasets=wikitext-2-v1 \  # These get ignored because I hardcoded in the PTB dataset.
    --text_datasets_paths=wikitext \
    --disable_cosine_decay
```

https://wandb.ai/eihli/gato-control/runs/57htqgy2?nw=nwusereihli

![image](https://github.com/ManifoldRG/NEKO/assets/1719584/46c91e7d-9090-47c5-a68d-6e8fcc304059)
